### PR TITLE
add param group and make db version explicit

### DIFF
--- a/awsblog-building-resilient-applications/multi-region/1-infra-stackset/stack-db.yml
+++ b/awsblog-building-resilient-applications/multi-region/1-infra-stackset/stack-db.yml
@@ -77,13 +77,22 @@ Resources:
       ReplicaRegions:
         - Region: !If [PrimaryRegion, !Ref Region2, !Ref Region1]
 
+  DBClusterParameterGroup:
+    Type: AWS::RDS::DBClusterParameterGroup
+    Properties: 
+      DBClusterParameterGroupName: !Sub ${ProjectId}-dbcluster-paramgroup
+      Description: Parameter Group for ARC Blog
+      Family: aurora-postgresql14
+      Parameters:
+        timezone: US/Eastern
+
   DBGlobalCluster:
     Condition: PrimaryRegion
     Type: AWS::RDS::GlobalCluster
     Description: Global Database Cluster
     Properties:
       Engine: aurora-postgresql
-      EngineVersion: '12.8'
+      EngineVersion: 14.5
       GlobalClusterIdentifier: !Sub ${ProjectId}-global-cluster
       StorageEncrypted: true
 
@@ -94,14 +103,14 @@ Resources:
     Properties:
       DatabaseName: !If [PrimaryRegion, !Ref DBName, !Ref AWS::NoValue]
       DBClusterIdentifier: !Sub ${ProjectId}-cluster-${AWS::Region}
-      DBClusterParameterGroupName: default.aurora-postgresql12
+      DBClusterParameterGroupName: !Ref DBClusterParameterGroup
       DBSubnetGroupName: !Ref DBSubnetGroup
       EnableCloudwatchLogsExports:
         - postgresql
       EnableIAMDatabaseAuthentication: true
       Engine: aurora-postgresql
       EngineMode: global
-      EngineVersion: '12.8'
+      EngineVersion: 14.5
       GlobalClusterIdentifier: !If [PrimaryRegion, !Ref DBGlobalCluster, !Sub '${ProjectId}-global-cluster'] 
       KmsKeyId: !Ref DBKMSKey
       MasterUsername: !If [PrimaryRegion, !Sub '{{resolve:secretsmanager:${DBSecret}:SecretString:username}}', !Ref AWS::NoValue]

--- a/awsblog-building-resilient-applications/single-region/1-infra-stack/stack-db.yml
+++ b/awsblog-building-resilient-applications/single-region/1-infra-stack/stack-db.yml
@@ -72,6 +72,15 @@ Resources:
         SecretStringTemplate: '{"username":"postgres"}'
       Name: !Sub ${ProjectId}-DBSecret
 
+  DBClusterParameterGroup:
+    Type: AWS::RDS::DBClusterParameterGroup
+    Properties: 
+      DBClusterParameterGroupName: !Sub ${ProjectId}-dbcluster-paramgroup
+      Description: Parameter Group for ARC Blog
+      Family: aurora-postgresql14
+      Parameters:
+        timezone: US/Eastern
+
   DBCluster:
     Type: AWS::RDS::DBCluster
     Description: Database Cluster
@@ -79,12 +88,13 @@ Resources:
     Properties:
       DatabaseName: !If [PrimaryRegion, !Ref DBName, !Ref AWS::NoValue]
       DBClusterIdentifier: !Sub ${ProjectId}-cluster-${AWS::Region}
-      DBClusterParameterGroupName: default.aurora-postgresql12
+      DBClusterParameterGroupName: !Ref DBClusterParameterGroup
       DBSubnetGroupName: !Ref DBSubnetGroup
       EnableCloudwatchLogsExports:
         - postgresql
       EnableIAMDatabaseAuthentication: true
       Engine: aurora-postgresql
+      EngineVersion: 14.5
       KmsKeyId: !Ref DBKMSKey
       MasterUsername: !If [PrimaryRegion, !Sub '{{resolve:secretsmanager:${DBSecret}:SecretString:username}}', !Ref AWS::NoValue]
       MasterUserPassword: !If [PrimaryRegion, !Sub '{{resolve:secretsmanager:${DBSecret}:SecretString:password}}', !Ref AWS::NoValue]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added a parameter group resource in CFN since the template fails to build if the param group referenced in the dbcluster resource does not exist. Also defined the database version to prevent the stack from failing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
