### PR TITLE
Upgrade Lambda to nodejs16.x and remove DB version pinning

### DIFF
--- a/awsblog-building-resilient-applications/multi-region/1-infra-stackset/stack-db.yml
+++ b/awsblog-building-resilient-applications/multi-region/1-infra-stackset/stack-db.yml
@@ -83,7 +83,6 @@ Resources:
     Description: Global Database Cluster
     Properties:
       Engine: aurora-postgresql
-      EngineVersion: '12.8'
       GlobalClusterIdentifier: !Sub ${ProjectId}-global-cluster
       StorageEncrypted: true
 
@@ -94,14 +93,12 @@ Resources:
     Properties:
       DatabaseName: !If [PrimaryRegion, !Ref DBName, !Ref AWS::NoValue]
       DBClusterIdentifier: !Sub ${ProjectId}-cluster-${AWS::Region}
-      DBClusterParameterGroupName: default.aurora-postgresql12
       DBSubnetGroupName: !Ref DBSubnetGroup
       EnableCloudwatchLogsExports:
         - postgresql
       EnableIAMDatabaseAuthentication: true
       Engine: aurora-postgresql
       EngineMode: global
-      EngineVersion: '12.8'
       GlobalClusterIdentifier: !If [PrimaryRegion, !Ref DBGlobalCluster, !Sub '${ProjectId}-global-cluster'] 
       KmsKeyId: !Ref DBKMSKey
       MasterUsername: !If [PrimaryRegion, !Sub '{{resolve:secretsmanager:${DBSecret}:SecretString:username}}', !Ref AWS::NoValue]

--- a/awsblog-building-resilient-applications/multi-region/1-infra-stackset/stack-master.yml
+++ b/awsblog-building-resilient-applications/multi-region/1-infra-stackset/stack-master.yml
@@ -26,12 +26,12 @@ Mappings:
   RegionalParameters:
     us-east-1: # This must match Region1 above
       VpcCidr: 10.0.0.0/16 # Set this to the desired VPC CIDR for use in Region 1
-      DBQuantity: 3 # Set this to the desired number of database instances in Region 1
+      DBQuantity: 2 # Set this to the desired number of database instances in Region 1
       AsgMin: 1 # Set this to the desired minimum number of EC2 instances in Region 1
       AsgMax: 6 # Set this to the desired maximum number of EC2 instances in Region 1
     us-west-2: # This must match Region2 above
       VpcCidr: 10.1.0.0/16 # Set this to the desired VPC CIDR for use in Region 2
-      DBQuantity: 3 # Set this to the desired number of database instances in Region 2
+      DBQuantity: 1 # Set this to the desired number of database instances in Region 2
       AsgMin: 1 # Set this to the desired minimum number of EC2 instances in Region 2
       AsgMax: 6 # Set this to the desired maximum number of EC2 instances in Region 2
 

--- a/awsblog-building-resilient-applications/multi-region/3-lambda-stackset/stack-lambdas.yml
+++ b/awsblog-building-resilient-applications/multi-region/3-lambda-stackset/stack-lambdas.yml
@@ -252,7 +252,7 @@ Resources:
       Description: Lambda for status dashboard
       FunctionName: !Sub ${ProjectId}-Dashboard
       Role: !If [PrimaryRegion, !GetAtt DashboardLambdaRole.Arn, !Sub 'arn:aws:iam::${AWS::AccountId}:role/${ProjectId}-DashboardLambdaRole']
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Handler: dashboard-lambda.handler
       Environment:
         Variables: 
@@ -290,7 +290,7 @@ Resources:
     Type: AWS::Lambda::LayerVersion
     Properties:
       CompatibleRuntimes: 
-        - nodejs12.x
+        - nodejs16.x
       Content:
         S3Bucket: !FindInMap [RegionalParameters, !Ref AWS::Region, LambdaCodeS3Bucket]
         S3Key: !FindInMap [StaticParameters, StaticParameters, LambdaLayerS3Key]
@@ -355,7 +355,7 @@ Resources:
       Description: Lambda for scheduled Database failover check
       FunctionName: !Sub ${ProjectId}-DatabaseFailover
       Role: !If [PrimaryRegion, !GetAtt FailoverLambdaRole.Arn, !Sub 'arn:aws:iam::${AWS::AccountId}:role/${ProjectId}-FailoverLambdaRole']
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Handler: failover-lambda.handler
       Timeout: 5
       Layers:

--- a/awsblog-building-resilient-applications/single-region/1-infra-stack/stack-db.yml
+++ b/awsblog-building-resilient-applications/single-region/1-infra-stack/stack-db.yml
@@ -79,7 +79,6 @@ Resources:
     Properties:
       DatabaseName: !If [PrimaryRegion, !Ref DBName, !Ref AWS::NoValue]
       DBClusterIdentifier: !Sub ${ProjectId}-cluster-${AWS::Region}
-      DBClusterParameterGroupName: default.aurora-postgresql12
       DBSubnetGroupName: !Ref DBSubnetGroup
       EnableCloudwatchLogsExports:
         - postgresql

--- a/awsblog-building-resilient-applications/single-region/1-infra-stack/stack-master.yml
+++ b/awsblog-building-resilient-applications/single-region/1-infra-stack/stack-master.yml
@@ -25,7 +25,7 @@ Mappings:
   RegionalParameters:
     us-east-1: # This must match Region1 above
       VpcCidr: 10.0.0.0/16 # Set this to the desired VPC CIDR for use in Region 1
-      DBQuantity: 3 # Set this to the desired number of database instances in Region 1
+      DBQuantity: 2 # Set this to the desired number of database instances in Region 1
       AsgMin: 1 # Set this to the desired minimum number of EC2 instances in Region 1
       AsgMax: 6 # Set this to the desired maximum number of EC2 instances in Region 1
 

--- a/awsblog-building-resilient-applications/single-region/3-lambda-stack/stack-lambdas.yml
+++ b/awsblog-building-resilient-applications/single-region/3-lambda-stack/stack-lambdas.yml
@@ -181,7 +181,7 @@ Resources:
       Description: Lambda for status dashboard
       FunctionName: !Sub ${ProjectId}-Dashboard
       Role: !If [PrimaryRegion, !GetAtt DashboardLambdaRole.Arn, !Sub 'arn:aws:iam::${AWS::AccountId}:role/${ProjectId}-DashboardLambdaRole']
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Handler: dashboard-lambda.handler
       Environment:
         Variables: 


### PR DESCRIPTION
Based on feedback from a blog reader, making the following updates:
* Upgrading Lambda to the nodejs16.x runtime which is the latest supported runtime supporting the AWS JS v2 SDK to avoid too much additional refactoring
* Removing DB version pinning / parameter group references to enable the latest supported version of Aurora Postgres to be deployed at any time
* Reduced the default number of databases to reduce cost for anyone experimenting with this

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
